### PR TITLE
Add QuoteBoundary scope tool to invoicing resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ See the full breakdown in the **[USDT Payments Handbook](https://github.com/Payr
 ## Invoicing Tools
 
 - **[Freelance Invoice Templates](https://github.com/PayrollFlow/freelance-invoice-templates)** — Free, ready-to-use invoice templates (including a USDT/crypto invoice) for international clients.
+- **[QuoteBoundary](https://quoteboundary.evanguy.chatgpt.site/?utm_source=github&utm_medium=awesome_list&utm_campaign=awesome_freelancer_payments&utm_content=scope_quote_tools)** — Free browser toolkit for defining project scope, setting quote boundaries, and documenting change requests before invoicing.
 - **Wave / Zoho Invoice / Invoice Ninja** — Free or low-cost invoicing apps for recurring billing.
 
 ## Choosing a Method


### PR DESCRIPTION
Adds one concise, factual entry to the existing Invoicing Tools section for a free browser toolkit that helps freelancers define project scope, set quote boundaries, and document change requests before invoicing.

Tracked link: https://quoteboundary.evanguy.chatgpt.site/?utm_source=github&utm_medium=awesome_list&utm_campaign=awesome_freelancer_payments&utm_content=scope_quote_tools

No paid placement or reciprocal-link request is involved.